### PR TITLE
Restructure docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,10 +66,12 @@
     "scripts": {
         "check": [
             "@cs",
-            "@test"
+            "@test",
+            "docheader"
         ],
         "cs": "php-cs-fixer fix -v --diff --dry-run",
         "cs-fix": "php-cs-fixer fix -v --diff",
+        "docheader": "docheader check src/ tests/",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "prooph/snapshot-store" : "^1.1"
+        "prooph/snapshot-store" : "^1.1",
         "mongodb/mongodb": "^1.1.0"
     },
     "require-dev": {

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,9 +1,11 @@
 {
-  "title": "Prooph PDO SnapshotStore",
+  "title": "MongoDB Snapshot Store",
   "content": [
-    {"intro": "../README.md"},
+    {"intro": "introduction.md"},
     {"interop_factories": "interop_factories.md"}
   ],
+  "tocDepth": 1,
+  "numbering": false,
   "target": "./html",
   "template": "../vendor/prooph/bookdown-template/templates/main.php"
 }

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,15 @@
+# Overview
+
+MongoDB implementation of snapshot store
+
+## Installation
+
+```bash
+composer require prooph/mongodb-snapshot-store
+```
+
+## Requirements
+
+- PHP 7.1
+- MongoDB >= 3.4
+- PHP MongoDB Extension

--- a/tests/Container/MongoDbSnapshotStoreFactoryTest.php
+++ b/tests/Container/MongoDbSnapshotStoreFactoryTest.php
@@ -72,7 +72,9 @@ class MongoDbSnapshotStoreFactoryTest extends TestCase
 
         $container->get('my_connection')->willReturn($client)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
-        $container->get('serializer_servicename')->willReturn(new CallbackSerializer(function() {}, function() {}))->shouldBeCalled();
+        $container->get('serializer_servicename')->willReturn(new CallbackSerializer(function () {
+        }, function () {
+        }))->shouldBeCalled();
 
         $factory = new MongoDbSnapshotStoreFactory();
         $snapshotStore = $factory($container->reveal());


### PR DESCRIPTION
According to https://github.com/prooph/proophessor/issues/38#issuecomment-336200542

- shorter headlines
- introduction instead of using entire README (better overview while browsing through the docs)